### PR TITLE
Fix docstring in Caesar encoder

### DIFF
--- a/caesar/c_encode.py
+++ b/caesar/c_encode.py
@@ -3,7 +3,7 @@
 Caesar Cipher Encoder
 
 Usage:
-  python3 caesar_encode.py --shift N "Your plaintext here"
+  python3 c_encode.py --shift N "Your plaintext here"
 
 This script applies a positive Caesar shift to encode input text.
 """


### PR DESCRIPTION
## Summary
- correct script name in `c_encode.py` usage example

## Testing
- `python3 caesar/c_encode.py --shift 3 "Hello"`

------
https://chatgpt.com/codex/tasks/task_e_684091fdbbd08323bddf660a843d7c9e