### PR TITLE
Fix Vigenère ciphers package

### DIFF
--- a/vigenere_cipher.py/ciphers/__init__.py
+++ b/vigenere_cipher.py/ciphers/__init__.py
@@ -1,0 +1,1 @@
+"""Cipher implementations for the Vigenère toolkit."""


### PR DESCRIPTION
## Summary
- rename wrongly spelled `__inity__.py` to `__init__.py`
- add a small module docstring

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68421da599548323bf1d9d13884d44cc