### PR TITLE
Fix missing os import

### DIFF
--- a/vigenere_cipher.py/notify_helpers.py
+++ b/vigenere_cipher.py/notify_helpers.py
@@ -4,6 +4,7 @@ import smtplib
 from email.message import EmailMessage
 import requests
 import logging
+import os
 
 logger = logging.getLogger("vigenere_tool.notify")
 


### PR DESCRIPTION
## Summary
- import `os` in `notify_helpers` so functions can access os.path

## Testing
- `python -m py_compile vigenere_cipher.py/notify_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68421da1add883238ee3441bd5131de4