### PR TITLE
Add crib-based hints for Vigenère CLI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ Each folder contains a standalone module or utility designed to analyze, break, 
 | Module | Description |
 |--------|-------------|
 | `caesar/` | Caesar Cipher decoding suite with scoring heuristics, brute-force, TUI slider, and GPT-backed fallback |
-| `vigenere_cipher.py/` | Advanced Vigenère cracking CLI with IC & Kasiski analysis, wordfreq and n‑gram scoring, hill‑climb/annealing attacks, and batch/watch modes |
+| `vigenere_cipher.py/` | Advanced Vigenère cracking CLI with IC & Kasiski analysis, wordfreq and n‑gram scoring, hill‑climb/annealing attacks, batch/watch modes, and crib-based key hints |
 | `substitution/` | *(Planned)* Tools for breaking monoalphabetic substitution ciphers using statistical methods |
 | `rsa/` | *(Planned)* Modular RSA demo with key generation, signing, and encryption primitives |
 | `playfair/` | *(Planned)* Playfair cipher grid tools for encoding/decoding and visualization |
@@ -46,6 +46,8 @@ Copy
 Edit
 cd caesar
 python3 c_decode.py "Encrypted Message Here"
+cd ../vigenere_cipher.py
+python3 cli.py -c "CIPHERTEXT" --crib "KNOWNPLAINTEXT"
 📊 Tooling Philosophy
 No fluff. Every tool is designed to run from the command line with minimal overhead.
 

--- a/vigenere_cipher.py/cli.py
+++ b/vigenere_cipher.py/cli.py
@@ -53,6 +53,8 @@ def load_config(profile: str, config_path: str = "config.yaml") -> dict:
               help="Enable or disable Kasiski examination. Overrides config.")
 @click.option("--wordlist", "-l", type=click.Path(exists=True),
               help="Path to a local wordlist file for dictionary fallback (length ≤ 4).")
+@click.option("--crib", "-x", type=str,
+              help="Known plaintext fragment used as a crib for key hints.")
 @click.option("--max-keylen", "-k", type=int, default=None,
               help="Maximum key length for IC/frequency analysis. Overrides config.")
 @click.option("--top-lengths", "-n", type=int, default=None,
@@ -75,6 +77,7 @@ def main(
     watch,
     use_kasiski,
     wordlist,
+    crib,
     max_keylen,
     top_lengths,
     top_results,
@@ -112,6 +115,7 @@ def main(
         click.echo(f"  Profile:        {profile}")
         click.echo(f"  Use Kasiski:    {use_kasiski}")
         click.echo(f"  Wordlist Path:  {wordlist}")
+        click.echo(f"  Crib:          {crib}")
         click.echo(f"  Max Key Length: {max_keylen}")
         click.echo(f"  Top Lengths:    {top_lengths}")
         click.echo(f"  Top Results:    {top_results}")
@@ -171,6 +175,7 @@ def main(
                             ct_raw,
                             use_kasiski=use_kasiski,
                             wordlist_path=wordlist,
+                            crib=crib,
                             max_key_length=max_keylen,
                             top_n_lengths=top_lengths,
                             top_n_results=top_results,
@@ -236,6 +241,7 @@ def main(
                         ct_raw,
                         use_kasiski=use_kasiski,
                         wordlist_path=wordlist,
+                        crib=crib,
                         max_key_length=max_keylen,
                         top_n_lengths=top_lengths,
                         top_n_results=top_results,
@@ -286,6 +292,7 @@ def main(
                 ct_raw,
                 use_kasiski=use_kasiski,
                 wordlist_path=wordlist,
+                crib=crib,
                 max_key_length=max_keylen,
                 top_n_lengths=top_lengths,
                 top_n_results=top_results


### PR DESCRIPTION
## Summary
- implement `apply_crib` to derive key fragments from a crib
- allow `crack_vigenere` to use crib hints
- add `--crib` option in `cli.py`
- document crib usage in README

## Testing
- `python -m py_compile vigenere_cipher.py/tools/vigenere_crack_core.py vigenere_cipher.py/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6842273d4c1c83239cc34713ee07f96c