### PR TITLE
Add autokey and homophonic Vigenère support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ Each folder contains a standalone module or utility designed to analyze, break, 
 | Module | Description |
 |--------|-------------|
 | `caesar/` | Caesar Cipher decoding suite with scoring heuristics, brute-force, TUI slider, and GPT-backed fallback |
-| `vigenere_cipher.py/` | Advanced Vigenère cracking CLI with IC & Kasiski analysis, wordfreq and n‑gram scoring, hill‑climb/annealing attacks, batch/watch modes, and crib-based key hints |
+| `vigenere_cipher.py/` | Advanced Vigenère cracking CLI with IC & Kasiski analysis, wordfreq and n‑gram scoring, hill‑climb/annealing attacks, batch/watch modes, crib-based key hints, and variant support (`--variant autokey|homophonic`) |
 | `substitution/` | *(Planned)* Tools for breaking monoalphabetic substitution ciphers using statistical methods |
 | `rsa/` | *(Planned)* Modular RSA demo with key generation, signing, and encryption primitives |
 | `playfair/` | *(Planned)* Playfair cipher grid tools for encoding/decoding and visualization |

--- a/vigenere_cipher.py/README.md
+++ b/vigenere_cipher.py/README.md
@@ -1,0 +1,10 @@
+# Vigenère Cipher Toolkit
+
+This module provides a flexible command-line interface for analysing and breaking Vigenère encrypted texts.
+
+```
+python3 cli.py -c "LXFOPVEFRNHR" -x HELLO --variant autokey
+```
+
+The `--variant` flag accepts `standard`, `autokey`, or `homophonic`. When using the homophonic variant, supply `--homophonic-map path/to/map.json` with a JSON dictionary describing the cipher symbol mapping.
+

--- a/vigenere_cipher.py/ciphers/vigenere.py
+++ b/vigenere_cipher.py/ciphers/vigenere.py
@@ -8,7 +8,39 @@ def repeat_key(key: str, length: int) -> str:
     key = key.upper()
     return (key * (length // len(key) + 1))[:length]
 
-def vigenere_encrypt(text: str, keyword: str) -> str:
+from typing import Dict, Iterable, Optional
+
+
+def _map_encrypt(ch: str, mapping: Optional[Dict[str, Iterable[str]]]) -> str:
+    """Map a ciphertext character using the homophonic mapping (first option)."""
+    if not mapping:
+        return ch
+    opts = mapping.get(ch)
+    if not opts:
+        return ch
+    if isinstance(opts, str):
+        return opts[0]
+    try:
+        return next(iter(opts))
+    except StopIteration:
+        return ch
+
+
+def _map_decrypt(ch: str, mapping: Optional[Dict[str, Iterable[str]]]) -> str:
+    """Reverse-map a ciphertext character back to its canonical letter."""
+    if not mapping:
+        return ch
+    for plain, opts in mapping.items():
+        if isinstance(opts, str):
+            if ch in opts:
+                return plain
+        else:
+            if ch in opts:
+                return plain
+    return ch
+
+
+def vigenere_encrypt(text: str, keyword: str, homophonic_map: Optional[Dict[str, Iterable[str]]] = None) -> str:
     """
     Encrypt the input text using the Vigenère cipher with the given keyword.
     Only alphabetic characters are shifted; other characters are preserved.
@@ -23,6 +55,7 @@ def vigenere_encrypt(text: str, keyword: str) -> str:
             k_char = key[key_idx % len(key)]
             shift = ord(k_char) - ord('A')
             encrypted_char = chr((ord(t_char) - ord('A') + shift) % 26 + ord('A'))
+            encrypted_char = _map_encrypt(encrypted_char, homophonic_map)
             result.append(encrypted_char)
             key_idx += 1
         else:
@@ -30,7 +63,7 @@ def vigenere_encrypt(text: str, keyword: str) -> str:
 
     return ''.join(result)
 
-def vigenere_decrypt(text: str, keyword: str) -> str:
+def vigenere_decrypt(text: str, keyword: str, homophonic_map: Optional[Dict[str, Iterable[str]]] = None) -> str:
     """
     Decrypt the input text using the Vigenère cipher with the given keyword.
     Only alphabetic characters are shifted; other characters are preserved.
@@ -42,12 +75,57 @@ def vigenere_decrypt(text: str, keyword: str) -> str:
 
     for t_char in text:
         if t_char.isalpha():
+            t_mapped = _map_decrypt(t_char, homophonic_map)
             k_char = key[key_idx % len(key)]
             shift = ord(k_char) - ord('A')
-            decrypted_char = chr((ord(t_char) - ord('A') - shift + 26) % 26 + ord('A'))
+            decrypted_char = chr((ord(t_mapped) - ord('A') - shift + 26) % 26 + ord('A'))
             result.append(decrypted_char)
             key_idx += 1
         else:
             result.append(t_char)
 
+    return ''.join(result)
+
+
+def vigenere_autokey_encrypt(
+    text: str,
+    keyword: str,
+    homophonic_map: Optional[Dict[str, Iterable[str]]] = None,
+) -> str:
+    """Encrypt text using the autokey variant (keyword + plaintext)."""
+    text = text.upper()
+    key_queue = list(keyword.upper())
+    result = []
+    for t_char in text:
+        if t_char.isalpha():
+            k_char = key_queue.pop(0)
+            shift = ord(k_char) - ord('A')
+            enc = chr((ord(t_char) - ord('A') + shift) % 26 + ord('A'))
+            enc = _map_encrypt(enc, homophonic_map)
+            result.append(enc)
+            key_queue.append(t_char)
+        else:
+            result.append(t_char)
+    return ''.join(result)
+
+
+def vigenere_autokey_decrypt(
+    text: str,
+    keyword: str,
+    homophonic_map: Optional[Dict[str, Iterable[str]]] = None,
+) -> str:
+    """Decrypt an autokey Vigenère ciphertext."""
+    text = text.upper()
+    key_queue = list(keyword.upper())
+    result = []
+    for t_char in text:
+        if t_char.isalpha():
+            mapped = _map_decrypt(t_char, homophonic_map)
+            k_char = key_queue.pop(0)
+            shift = ord(k_char) - ord('A')
+            plain = chr((ord(mapped) - ord('A') - shift + 26) % 26 + ord('A'))
+            result.append(plain)
+            key_queue.append(plain)
+        else:
+            result.append(t_char)
     return ''.join(result)


### PR DESCRIPTION
## Summary
- extend Vigenère cipher module with autokey variant and homophonic mapping
- allow cracker core and CLI to specify variants
- add `--variant` and `--homophonic-map` CLI options
- document new features

## Testing
- `python3 -m py_compile vigenere_cipher.py/ciphers/vigenere.py vigenere_cipher.py/cli.py vigenere_cipher.py/tools/vigenere_crack_core.py`

------
https://chatgpt.com/codex/tasks/task_e_68422ab619988323b632348de9b7d326